### PR TITLE
Fix tensor size mismatch runtime error

### DIFF
--- a/Snowpark_PyTorch_Image_Rec.ipynb
+++ b/Snowpark_PyTorch_Image_Rec.ipynb
@@ -183,7 +183,7 @@
     "  import os\n",
     "\n",
     "  model, transform, cls_idx = load_model()\n",
-    "  img = Image.open(load_image(image_bytes_in_str))\n",
+    "  img = Image.open(load_image(image_bytes_in_str)).convert('RGB')\n",
     "  img = transform(img).unsqueeze(0)\n",
     "\n",
     "  # Get model output and human text prediction\n",


### PR DESCRIPTION
RuntimeError: The size of tensor a (4) must match the size of tensor b (3) at non-singleton dimension 0
 in function IMAGE_RECOGNITION_USING_BYTES with handler udf_py_890417572.compute